### PR TITLE
feat: broaden email tracking pixel coverage

### DIFF
--- a/line-block.txt
+++ b/line-block.txt
@@ -1,11 +1,11 @@
 ! ================================
 ! Title: LINE App 廣告通用阻擋
 ! Description: 阻擋 LINE 應用程式內廣告，保留聊天功能並阻擋大部分廣告相關服務
-! Version: 1.2.0
+! Version: 1.2.1
 ! Author: Gazelle
 ! Homepage: https://github.com/gazelle/adguard-rules
 ! License: MIT
-! TimeUpdated: 2025-08-21T02:00:00.000Z
+! TimeUpdated: 2025-08-25T11:00:00.000Z
 ! ================================
 
 ! ===== LINE 官方廣告／量測 API =====
@@ -71,7 +71,7 @@
 ||tapjoy.com^$important
 ||vungle.com^$important
 ||unityads.unity3d.com^$important
-||ironSource.mobi^$important
+||ironsource.mobi^$important
 ||chartboost.com^$important
 
 ! ===== 日本常見廣告供應商（LINE SDK 內嵌）=====

--- a/mail-block.txt
+++ b/mail-block.txt
@@ -1,11 +1,11 @@
 ! ============================================
 ! Title: 郵件／EDM 追蹤像素通用阻擋
 ! Description: 封鎖電子郵件中的追蹤像素與開信行為追蹤
-! Version: 1.2.11
+! Version: 1.2.12
 ! Author: Gazelle
 ! Homepage: https://github.com/gazelle/adguard-rules
 ! License: MIT
-! TimeUpdated: 2025-08-25T09:50:00.000Z
+! TimeUpdated: 2025-08-25T11:00:00.000Z
 ! ============================================
 
 ! ========== 行銷路徑通用追蹤端點 ==========
@@ -44,6 +44,13 @@
 ||emails.github.com/trk?*
 ||*.sendibm*.com/im/*?u=*$image
 ||email.focusrite.com/e3t/*
+
+! 常見電子報平台追蹤像素
+||list-manage.com/track/open.php?*$image
+||mailchimp.com/track/open.php?*$image
+||ct.sendgrid.net/wf/open?*$image
+||mandrillapp.com/track/open.php?*$image
+||sparkpostmail.com/wf/open?*$image
 
 ! ===== Humble Bundle 郵件追蹤阻擋 =====
 ! 阻擋所有 mailer.humblebundle.com 的追蹤轉址


### PR DESCRIPTION
## Summary
- add common email service provider tracking endpoints and bump mail filter metadata
- standardize ironsource domain casing in the LINE filter

## Testing
- `npx @adguard/aglint line-block.txt mail-block.txt gamer.txt` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@adguard%2faglint)*

------
https://chatgpt.com/codex/tasks/task_e_68ac35331c84832884b1ad613a6a922d